### PR TITLE
Add support for Huawei B528s-23a router

### DIFF
--- a/upnp_port_forward/client.py
+++ b/upnp_port_forward/client.py
@@ -100,6 +100,7 @@ WAN_SERVICE_NAMES = (
     "WANIPConn1",
     "WANIPConnection.1",  # Nighthawk C7800
     "WANPPPConnection.1",  # CenturyLink C1100Z
+    "WANPPPConn1",  # Huawei B528s-23a
 )
 
 


### PR DESCRIPTION
## What was wrong?

Port forward didn't work on my Huawei B528s-23a router.

## How was it fixed?

Add router's WAN service name: `WANPPPConn1` to the list of recognized WAN service names.