### PR TITLE
Easier upnp support

### DIFF
--- a/docs/upnp_port_forward.rst
+++ b/docs/upnp_port_forward.rst
@@ -1,6 +1,9 @@
 API
 ===
 
+Setting up UpnP port forwarding
+-------------------------------
+
 This library exposes a simple interface for setting up UPnP port forwarding.
 
 .. code-block:: python
@@ -18,6 +21,30 @@ This library exposes a simple interface for setting up UPnP port forwarding.
             f"external_ip={external_ip}"
         )
     
+
+If one or several service names allowing port mapping are known (see below: `Exporting port mapping services`_), the library can be forced to use them:
+
+.. code-block:: python
+
+        internal_ip, external_ip = setup_port_map(port, required_service_names=("service name 1", "service name 2",))
+
+
+
+Exporting port mapping services
+-------------------------------
+
+The export module provides a simple way to get the available UPnP service names allowing port mapping.
+
+.. code-block:: sh
+
+    python upnp_port_forward/tools/export.py
+
+or
+
+.. code-block:: sh
+
+    python -m upnp_port_forward.tools.export
+
 
 .. automodule:: upnp_port_forward
     :members:

--- a/docs/upnp_port_forward.tools.rst
+++ b/docs/upnp_port_forward.tools.rst
@@ -1,0 +1,22 @@
+upnp\_port\_forward.tools package
+=================================
+
+Submodules
+----------
+
+upnp\_port\_forward.tools.export module
+---------------------------------------
+
+.. automodule:: upnp_port_forward.tools.export
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: upnp_port_forward.tools
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/tests/core/tools/test_export.py
+++ b/tests/core/tools/test_export.py
@@ -1,0 +1,35 @@
+import logging
+
+import pytest
+
+from upnp_port_forward.tools.export import UPnPServiceNames, output_upnp_service_names
+
+
+@pytest.fixture
+def upnp_service_names():
+    upnp_service_name_1 = UPnPServiceNames(
+        "Device 1", "Location 1", ("Service 1.1", "Service 1.2")
+    )
+    upnp_service_name_2 = UPnPServiceNames(
+        "Device 2", "Location 2", ("Service 2.1", "Service 2.2")
+    )
+    return (upnp_service_name_1, upnp_service_name_2)
+
+
+def test_output_upnp_service_names(upnp_service_names, caplog):
+    expected_output = (
+        "Device Name:     Device 1\n"
+        "Device Location: Location 1\n"
+        "Available UPnP services found on this device:\n"
+        "  Service 1.1\n"
+        "  Service 1.2\n"
+        "\n"
+        "Device Name:     Device 2\n"
+        "Device Location: Location 2\n"
+        "Available UPnP services found on this device:\n"
+        "  Service 2.1\n"
+        "  Service 2.2\n"
+    )
+    caplog.set_level(logging.INFO)
+    output_upnp_service_names(upnp_service_names)
+    assert expected_output in caplog.text

--- a/upnp_port_forward/__init__.py
+++ b/upnp_port_forward/__init__.py
@@ -1,2 +1,2 @@
-from .client import setup_port_map  # noqa: F401
-from .exceptions import PortMapFailed  # noqa: F401
+from .client import fetch_add_portmapping_services, setup_port_map  # noqa: F401
+from .exceptions import NoPortMapServiceFound, PortMapFailed  # noqa: F401

--- a/upnp_port_forward/__init__.py
+++ b/upnp_port_forward/__init__.py
@@ -1,2 +1,2 @@
-from .client import fetch_add_portmapping_services, setup_port_map  # noqa: F401
+from .client import setup_port_map  # noqa: F401
 from .exceptions import NoPortMapServiceFound, PortMapFailed  # noqa: F401

--- a/upnp_port_forward/client.py
+++ b/upnp_port_forward/client.py
@@ -38,7 +38,7 @@ WAN_SERVICE_NAMES: Tuple[str, ...] = (
 def setup_port_map(
     port: int,
     duration: int = DEFAULT_PORTMAP_DURATION,
-    wan_service_names: Optional[Tuple[str, ...]] = None,
+    required_service_names: Optional[Tuple[str, ...]] = None,
 ) -> Tuple[AnyIPAddress, AnyIPAddress]:
     """
     Set up the port mapping
@@ -52,7 +52,7 @@ def setup_port_map(
     for upnp_dev in devices:
         try:
             internal_ip, external_ip = _setup_device_port_map(
-                upnp_dev, port, duration, wan_service_names,
+                upnp_dev, port, duration, required_service_names,
             )
             logger.info(
                 "NAT port forwarding successfully set up: internal=%s:%d external=%s:%d",
@@ -109,11 +109,11 @@ def _find_internal_ip_on_device_network(upnp_dev: upnpclient.upnp.Device) -> str
 
 
 def _get_wan_service(
-    upnp_dev: upnpclient.upnp.Device, wan_service_names: Optional[Tuple[str, ...]]
+    upnp_dev: upnpclient.upnp.Device, required_service_names: Optional[Tuple[str, ...]]
 ) -> upnpclient.upnp.Service:
 
     service_names_on_trial = (
-        wan_service_names if wan_service_names else WAN_SERVICE_NAMES
+        required_service_names if required_service_names else WAN_SERVICE_NAMES
     )
     for service_name in service_names_on_trial:
         try:
@@ -128,11 +128,11 @@ def _setup_device_port_map(
     upnp_dev: upnpclient.upnp.Device,
     port: int,
     duration: int,
-    wan_service_names: Optional[Tuple[str, ...]],
+    required_service_names: Optional[Tuple[str, ...]],
 ) -> Tuple[str, str]:
 
     internal_ip = _find_internal_ip_on_device_network(upnp_dev)
-    wan_service = _get_wan_service(upnp_dev, wan_service_names)
+    wan_service = _get_wan_service(upnp_dev, required_service_names)
 
     external_ip = wan_service.GetExternalIPAddress()["NewExternalIPAddress"]
 

--- a/upnp_port_forward/client.py
+++ b/upnp_port_forward/client.py
@@ -112,10 +112,10 @@ def _get_wan_service(
     upnp_dev: upnpclient.upnp.Device, required_service_names: Optional[Tuple[str, ...]]
 ) -> upnpclient.upnp.Service:
 
-    service_names_on_trial = (
+    candidate_service_names = (
         required_service_names if required_service_names else WAN_SERVICE_NAMES
     )
-    for service_name in service_names_on_trial:
+    for service_name in candidate_service_names:
         try:
             return upnp_dev[service_name]
         except KeyError:

--- a/upnp_port_forward/client.py
+++ b/upnp_port_forward/client.py
@@ -101,7 +101,7 @@ class UPnPServiceNames(NamedTuple):
     service_names: Tuple[str, ...]
 
 
-def fetch_AddPortMapping_services() -> Tuple[UPnPServiceNames, ...]:
+def fetch_add_portmapping_services() -> Tuple[UPnPServiceNames, ...]:
     """
     :return: returns the available devices and services for which the action 'AddPortMapping' exists
     """
@@ -126,6 +126,11 @@ def fetch_AddPortMapping_services() -> Tuple[UPnPServiceNames, ...]:
                     upnp_dev.friendly_name, upnp_dev.location, tuple(service_names)
                 )
             )
+
+    if len(services_with_AddPortMapping) <= 0:
+        raise NoPortMapServiceFound(
+            "Unable to find a device with a port mapping service"
+        )
 
     return tuple(services_with_AddPortMapping)
 

--- a/upnp_port_forward/exceptions.py
+++ b/upnp_port_forward/exceptions.py
@@ -1,2 +1,6 @@
 class PortMapFailed(Exception):
     pass
+
+
+class NoPortMapServiceFound(Exception):
+    pass

--- a/upnp_port_forward/tools/export.py
+++ b/upnp_port_forward/tools/export.py
@@ -1,0 +1,84 @@
+import logging
+from typing import NamedTuple, Tuple
+
+import upnpclient
+
+from upnp_port_forward.exceptions import NoPortMapServiceFound
+
+
+class UPnPServiceNames(NamedTuple):
+    device_friendly_name: str
+    device_location: str
+    service_names: Tuple[str, ...]
+
+
+def fetch_add_portmapping_services() -> Tuple[UPnPServiceNames, ...]:
+    """
+    :return: returns the available devices and services for which the action 'AddPortMapping' exists
+    """
+    devices = upnpclient.discover()
+    if not devices:
+        raise NoPortMapServiceFound("No UPnP devices available")
+
+    services_with_AddPortMapping = []
+    for upnp_dev in devices:
+        service_names = []
+        for service in upnp_dev.services:
+            try:
+                service["AddPortMapping"]
+            except KeyError:
+                continue
+            else:
+                service_names.append(service.name)
+
+        if len(service_names) > 0:
+            services_with_AddPortMapping.append(
+                UPnPServiceNames(
+                    upnp_dev.friendly_name, upnp_dev.location, tuple(service_names)
+                )
+            )
+
+    if len(services_with_AddPortMapping) <= 0:
+        raise NoPortMapServiceFound(
+            "Unable to find a device with a port mapping service"
+        )
+
+    return tuple(services_with_AddPortMapping)
+
+
+def main() -> None:
+    logger = logging.getLogger("upnp_port_forward.tools.export")
+    try:
+        upnp_service_names_by_device = fetch_add_portmapping_services()
+        service_names_output = "\n"
+        for service in upnp_service_names_by_device:
+            service_names_output = service_names_output.join(
+                [
+                    f"\n{'-' * 40}",
+                    f"Device Name: {service.device_friendly_name}",
+                    f"Device Location: {service.device_location}",
+                    "Available UPnP services found on this device:",
+                    "\n".join(
+                        f"    {service_name}" for service_name in service.service_names
+                    ),
+                ]
+            )
+        service_names_output = "\n".join(
+            [
+                service_names_output,
+                "You can now try to launch upnp_port_forward.client.setup_port_map()",
+                "with required_service_names=(<service name>, ...)",
+                "To help this library supports more routers, you can submit new service names",
+                "here: https://github.com/ethereum/upnp-port-forward/issues - Thanks !!",
+            ]
+        )
+
+        logging.basicConfig(level=logging.INFO)
+        logger.info(service_names_output)
+
+    except NoPortMapServiceFound:
+        logger.error("No port mapping services found")
+
+
+if __name__ == "__main__":
+    main()

--- a/upnp_port_forward/tools/export.py
+++ b/upnp_port_forward/tools/export.py
@@ -46,38 +46,47 @@ def fetch_add_portmapping_services() -> Tuple[UPnPServiceNames, ...]:
     return tuple(services_with_AddPortMapping)
 
 
+def output_upnp_service_names(
+    upnp_service_names_by_device: Tuple[UPnPServiceNames, ...]
+) -> None:
+    service_names_output = [
+        f"\n{'-' * 40}",
+    ]
+    for service in upnp_service_names_by_device:
+        service_names_output.extend(
+            [
+                f"Device Name:     {service.device_friendly_name}",
+                f"Device Location: {service.device_location}",
+                "Available UPnP services found on this device:",
+            ]
+        )
+        service_names_output.extend(
+            [f"  {service_name}" for service_name in service.service_names]
+        )
+        service_names_output.append("")
+
+    service_names_output.extend(
+        [
+            "You can now try to launch upnp_port_forward.client.setup_port_map()",
+            "with required_service_names=(<service name>, ...)",
+            "To help this library supports more routers, you can submit new service names",
+            "here: https://github.com/ethereum/upnp-port-forward/issues - Thanks !!",
+        ]
+    )
+
+    logger = logging.getLogger("upnp_port_forward.tools.export")
+    logging.basicConfig(level=logging.INFO)
+    logger.info("\n".join(service_names_output))
+
+
 def main() -> None:
     logger = logging.getLogger("upnp_port_forward.tools.export")
     try:
         upnp_service_names_by_device = fetch_add_portmapping_services()
-        service_names_output = "\n"
-        for service in upnp_service_names_by_device:
-            service_names_output = service_names_output.join(
-                [
-                    f"\n{'-' * 40}",
-                    f"Device Name: {service.device_friendly_name}",
-                    f"Device Location: {service.device_location}",
-                    "Available UPnP services found on this device:",
-                    "\n".join(
-                        f"    {service_name}" for service_name in service.service_names
-                    ),
-                ]
-            )
-        service_names_output = "\n".join(
-            [
-                service_names_output,
-                "You can now try to launch upnp_port_forward.client.setup_port_map()",
-                "with required_service_names=(<service name>, ...)",
-                "To help this library supports more routers, you can submit new service names",
-                "here: https://github.com/ethereum/upnp-port-forward/issues - Thanks !!",
-            ]
-        )
-
-        logging.basicConfig(level=logging.INFO)
-        logger.info(service_names_output)
-
     except NoPortMapServiceFound:
         logger.error("No port mapping services found")
+    else:
+        output_upnp_service_names(upnp_service_names_by_device)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What was wrong?
Only a limited number of upnp services are listed to setup portforwarding.
The list is hardcoded, it is not straight forward for users to identify the one used by their routers, and it is currently not possible to provide a specific one to Trinity.
See Trinity Issue https://github.com/ethereum/trinity/issues/1959 for more details

## How was it fixed?
The proposed enhancement is divided in 2 parts:

 1/ In ethereum/upnp-port-forward/client.py:
 - A new method `fetch_add_portmapping_services` retrieves and returns all available services which can map ports.
 - The method `setup_port_map` can now receive a service name as a new argument and uses it first to when it tries to map a port.

 2/ In ethereum/trinity:
 - A new component `UpnpServiceNamesComponent` exposes the new command line positional argument `export-upnp-info`, calls `fetch_add_portmapping_services` and print the results, if any, on the terminal.
 - The component `UpnpComponent` exposes now a new command line optional argument `--upnp-service-name` which allows the user to provide a upnp service name to Trinity. This service name is provided to the function `setup_port_map`.

### To-Do

The PR on the Trinity side is ~coming soon~ https://github.com/ethereum/trinity/pull/2116.

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/upnp-port-forward/blob/master/newsfragments/README.md)

[//]: # (See: https://upnp-port-forward.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/upnp-port-forward/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](http://www.luvbat.com/uploads/rabbit_in_field_of_flowers__8146604322.jpg)
